### PR TITLE
Fix for demo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
         node-version: '10.x'
 
     - name: 'Run npm'
-      shell: pwsh
+      shell: bash
       run: |
         # If your function app project is not located in your repository's root
         # Please change your directory for npm in pushd
@@ -38,10 +38,9 @@ jobs:
       uses: Azure/functions-action@v1
       id: fa
       with:
-        app-name: HelloWorldSlots
+        app-name: HelloWorldSlots-stage
         # If your function app project is not located in your repository's root
         # Please consider prefixing the project path in this package parameter
-        slot-name: stage
         package: '.'
         # If you want to use publish profile credentials instead of Azure Service Principal
         # Please uncomment the following line


### PR DESCRIPTION
The issue we were facing was reported here https://github.com/facebook/jest/issues/5064
**This is a jest issue**. PowerShell will interpreted all outputs in stderr as failure. Thus, I change that to use bash.

Before merging this PR please do the following steps:
1. Acquire the **HelloWorldSlots** function app **stage** slot SCM credentials and placed it in GitHub repository secret **SCM_CREDENTIALS**.
2. In the **HelloWorldSlots** function app **stage** slot app settings, add **WEBSITE_RUN_FROM_PACKAGE = 1** manually, (since SCM credentials do not have privilege to change app settings)

There's a limitation in slot deployment using **slot-name** with SCM for WebApp and FunctionApp GitHub Actions. The related issues are here, https://github.com/Azure/webapps-deploy/issues/6, https://github.com/Azure/functions-action/issues/25